### PR TITLE
Feat #9: 카카오 로그인 구현

### DIFF
--- a/src/main/java/com/umc/zipcock/config/auth/SecurityConfig.java
+++ b/src/main/java/com/umc/zipcock/config/auth/SecurityConfig.java
@@ -57,6 +57,6 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
     }
 
     private static final String[] AUTH_WHITELIST ={
-            "/","/css/**","/images/**","/js/**","/h2-console/**","/v3/api-docs/**","/swagger-ui/**", "/login", "/join", "/check-email"
+            "/","/css/**","/images/**","/js/**","/h2-console/**","/v3/api-docs/**","/swagger-ui/**", "/login", "/join", "/check-email", "/oauth/**"
     };
 }

--- a/src/main/java/com/umc/zipcock/controller/api/user/UserController.java
+++ b/src/main/java/com/umc/zipcock/controller/api/user/UserController.java
@@ -13,6 +13,7 @@ import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
@@ -33,15 +34,15 @@ public class UserController {
 
     @ApiOperation(value = "카카오 로그인 API")
     @GetMapping("/oauth/token")
-    public DefaultRes kakaoLogin(@RequestParam String code) {
+    public ResponseEntity<DefaultRes> kakaoLogin(@RequestParam String code) {
 
         // 넘어온 인가 코드를 통해 access Token 발급
         OauthToken oauthToken = securityService.getAccessToken(code);
 
-        // 발급 받은 accessToken 으로 카카오 회원 정보 DB 저장
-        User user = securityService.saveKakaoUser(oauthToken.getAccess_token());
+        // 발급 받은 accessToken 으로 카카오 회원 정보 DB 저장 후 우리 서비스의 Access Token, Refresh Token 발급
+        DefaultRes res = securityService.saveKakaoUser(oauthToken.getAccess_token());
 
-        return DefaultRes.response(HttpStatus.OK.value(), "로그인에 성공하였습니다.", user);
+        return new ResponseEntity<>(res, HttpStatus.OK);
     }
 
     @ApiOperation(value = "회원가입 API" , notes = "로그인에 성공하면 토큰을 헤더에 넣어서 반환합니다. Authorization 헤더에 AccessToken을 넣어주세요")

--- a/src/main/java/com/umc/zipcock/controller/api/user/UserController.java
+++ b/src/main/java/com/umc/zipcock/controller/api/user/UserController.java
@@ -5,16 +5,16 @@ import com.umc.zipcock.model.dto.request.jwt.TokenReqDto;
 import com.umc.zipcock.model.dto.request.user.EmailCheckReqDto;
 import com.umc.zipcock.model.dto.request.user.JoinReqDto;
 import com.umc.zipcock.model.dto.request.user.LoginReqDto;
+import com.umc.zipcock.model.dto.resposne.auth.OauthToken;
 import com.umc.zipcock.model.dto.resposne.jwt.TokenResDto;
 import com.umc.zipcock.model.entity.user.User;
 import com.umc.zipcock.service.jwt.SecurityService;
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import javax.validation.Valid;
 
@@ -25,10 +25,25 @@ public class UserController {
 
     private final SecurityService securityService;
 
-    @ApiOperation(value = "로그인 API" , notes = "로그인에 성공하면 토큰을 헤더에 넣어서 반환합니다. Authorization 헤더에 AccessToken을 넣어주세요")
+    @ApiOperation(value = "일반 로그인 API" , notes = "로그인에 성공하면 토큰을 헤더에 넣어서 반환합니다. Authorization 헤더에 AccessToken을 넣어주세요")
     @PostMapping("/login")
     public TokenResDto login(@Valid @RequestBody LoginReqDto dto) {
         return securityService.login(dto);
+    }
+
+    @ApiOperation(value = "카카오 로그인 API")
+    @GetMapping("/oauth/token")
+    public DefaultRes kakaoLogin(@RequestParam String code) {
+
+        // 넘어온 인가 코드를 통해 access Token 발급
+        OauthToken oauthToken = securityService.getAccessToken(code);
+
+        // 발급 받은 accessToken 으로 카카오 회원 정보 DB 저장
+        // User user = securityService.saveKakaoUser(oauthToken.getAccess_token());
+
+        // return DefaultRes.response(HttpStatus.OK.value(), "로그인에 성공하였습니다.", user);
+
+        return DefaultRes.response(HttpStatus.OK.value(),"액세스 토큰 발급 성공", oauthToken);
     }
 
     @ApiOperation(value = "회원가입 API" , notes = "로그인에 성공하면 토큰을 헤더에 넣어서 반환합니다. Authorization 헤더에 AccessToken을 넣어주세요")
@@ -42,7 +57,6 @@ public class UserController {
     public DefaultRes reissue(@AuthenticationPrincipal User user, @Valid @RequestBody TokenReqDto dto) {
         return securityService.reissue(user, dto);
     }
-
 
     @ApiOperation(value = "이메일 중복 확인을 위한 API")
     @PostMapping("/check-email")

--- a/src/main/java/com/umc/zipcock/controller/api/user/UserController.java
+++ b/src/main/java/com/umc/zipcock/controller/api/user/UserController.java
@@ -39,11 +39,9 @@ public class UserController {
         OauthToken oauthToken = securityService.getAccessToken(code);
 
         // 발급 받은 accessToken 으로 카카오 회원 정보 DB 저장
-        // User user = securityService.saveKakaoUser(oauthToken.getAccess_token());
+        User user = securityService.saveKakaoUser(oauthToken.getAccess_token());
 
-        // return DefaultRes.response(HttpStatus.OK.value(), "로그인에 성공하였습니다.", user);
-
-        return DefaultRes.response(HttpStatus.OK.value(),"액세스 토큰 발급 성공", oauthToken);
+        return DefaultRes.response(HttpStatus.OK.value(), "로그인에 성공하였습니다.", user);
     }
 
     @ApiOperation(value = "회원가입 API" , notes = "로그인에 성공하면 토큰을 헤더에 넣어서 반환합니다. Authorization 헤더에 AccessToken을 넣어주세요")

--- a/src/main/java/com/umc/zipcock/model/dto/resposne/auth/OauthToken.java
+++ b/src/main/java/com/umc/zipcock/model/dto/resposne/auth/OauthToken.java
@@ -1,0 +1,18 @@
+package com.umc.zipcock.model.dto.resposne.auth;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter @Setter
+@AllArgsConstructor
+@NoArgsConstructor
+public class OauthToken {
+    private String access_token;
+    private String token_type;
+    private String refresh_token;
+    private int expires_in;
+    private String scope;
+    private int refresh_token_expires_in;
+}

--- a/src/main/java/com/umc/zipcock/model/entity/user/User.java
+++ b/src/main/java/com/umc/zipcock/model/entity/user/User.java
@@ -32,7 +32,7 @@ public class User extends BaseEntity implements UserDetails {
     @Column(name = "user_id")
     private Long id;
 
-    @Column(nullable = false)
+    @Column
     private String email;
 
     @Column
@@ -75,8 +75,25 @@ public class User extends BaseEntity implements UserDetails {
     @Column
     private String thumbnail;
 
-    @Column(nullable = false)
+    @Column
     private String password;
+
+    @Column
+    private Long kakaoId;
+
+    @Column
+    private String kakaoNickname;
+
+    @Column
+    private String kakaoEmail;
+
+    @Builder
+    public User(Long kakaoId, String kakaoNickname, String kakaoEmail){
+        this.kakaoId = kakaoId;
+        this.kakaoNickname = kakaoNickname;
+        this.kakaoEmail = kakaoEmail;
+    }
+
 
     // 권한
     // @Enumerated(EnumType.STRING)

--- a/src/main/java/com/umc/zipcock/model/util/KakaoProfile.java
+++ b/src/main/java/com/umc/zipcock/model/util/KakaoProfile.java
@@ -1,0 +1,34 @@
+package com.umc.zipcock.model.util;
+
+import lombok.Data;
+
+@Data
+public class KakaoProfile {
+
+    public Long id;
+    public String connected_at;
+    public Properties properties;
+    public KakaoAccount kakao_account;
+
+    @Data
+    public class Properties { //(1)
+        public String nickname;
+    }
+
+    @Data
+    public class KakaoAccount { //(2)
+        public Boolean profile_nickname_needs_agreement;
+        public Profile profile;
+        public Boolean email_needs_agreement;
+        public Boolean is_email_valid;
+        public Boolean is_email_verified;
+        public Boolean has_email;
+        public String email;
+
+        @Data
+        public class Profile {
+            public String nickname;
+        }
+
+    }
+}

--- a/src/main/java/com/umc/zipcock/repository/user/UserRepository.java
+++ b/src/main/java/com/umc/zipcock/repository/user/UserRepository.java
@@ -8,4 +8,6 @@ import java.util.Optional;
 
 public interface UserRepository extends JpaRepository<User, Long> {
     Optional<User> findByEmail(@Param("email") String email);
+
+    User findByKakaoEmail(String email);
 }

--- a/src/main/java/com/umc/zipcock/service/jwt/SecurityService.java
+++ b/src/main/java/com/umc/zipcock/service/jwt/SecurityService.java
@@ -183,7 +183,7 @@ public class SecurityService {
         return oauthToken;
     }
 
-    public User saveKakaoUser(String token) {
+    public DefaultRes saveKakaoUser(String token) {
 
         KakaoProfile profile = findProfile(token);
 
@@ -200,7 +200,19 @@ public class SecurityService {
             userRepository.save(user);
         }
 
-        return user;
+        // Access Token과 Refresh Token 새로 발급
+        TokenResDto tokenResDto = jwtTokenProvider.createToken(user.getEmail(), user.getId(), user.getRoleList());
+
+        // Refresh Token 저장
+        RefreshToken refreshToken = RefreshToken.builder()
+                .key(user.getId())
+                .token(tokenResDto.getRefreshToken())
+                .build();
+
+        refreshTokenRepository.save(refreshToken);
+
+        return DefaultRes.response(HttpStatus.OK.value(), "로그인에 성공하였습니다.", tokenResDto);
+
     }
 
     private KakaoProfile findProfile(String token) {


### PR DESCRIPTION
원래 인가 코드는 프론트에서 받아와 백엔드로 넘겨주는 것이지만, 프론트와의 연동 전 백엔드에서 카카오 액세스 토큰 발급 기능이 정상 동작하는지 확인하기 위해 임시로 서버에서 인가 코드를 받아오기 위해 redirect_url의 포트번호를 8080으로 설정했으나 추후, 수정이 필요하다.

### 서버에서 임시로 인가 코드를 받는 방법
https://kauth.kakao.com/oauth/authorize?client_id={REST_API_KEY}&redirect_uri={REDIRECT_URI}&response_type=code
로 접근하여 동의하고 계속하기 버튼을 클릭하면

다음과 같은 URL로 리다이렉트 된다.
http://localhost:8080/oauth?code=TRciDgLbalyM13woMJ7XenEigtdo9vw8GxVnGyrceAZ1onqbgwytwcNuKNaorw8Hdgc5OwoqJVIAAAGF6D3f5A

인가 코드를 넘겨 받아, 액세스 토큰을 발급하는 아래 메소드를 테스트하기 위해 포스트맨에서 테스트를 진행한다.
![image](https://user-images.githubusercontent.com/62657545/214526648-eb88b96d-a4f6-495a-a4c5-e6f09a391cc9.png)


### Postman 액세스 토큰 발급 테스트

다음과 같이, 인가 코드를 넘겨 받아 카카오 액세스 토큰을 발급받는 기능이 정상적으로 동작함을 테스트 하였다.
![image](https://user-images.githubusercontent.com/62657545/214526951-712f7ee6-30a4-4bb3-8640-e2172384372e.png)



### Postman 인가 코드를 통해 발급받은 kakao Access Token으로 가져온 Kakao 사용자 정보를 DB에 저장하는 기능 테스트
![image](https://user-images.githubusercontent.com/62657545/214551272-3e6c19ff-9e52-4627-8ee2-6edcf6cdc534.png)
![image](https://user-images.githubusercontent.com/62657545/214551227-bc653f7e-aeb4-4be5-8ec0-aa140ef8e5e5.png)

카카오 로그인시, 인가 코드를 통해 발급받은 kakao Access Token으로 가져온 Kakao 사용자 정보를 사용해 우리 서비스의
AccessToken과 RefreshToken을 발급하여 응답 값으로 반환한다.

### Postman Kakao Access Token을 사용해 우리 서비스의 Access Token과 Refresh Token을 발급하여 반환하는 기능 테스트
![image](https://user-images.githubusercontent.com/62657545/214553925-ddc1a841-bc67-47fd-a45d-309a5a005b3c.png)


### Postman 카카오 로그인을 통해 발급된 Access Token을 사용해, 테스트용 API에 접근이 잘 되는지 테스트
![image](https://user-images.githubusercontent.com/62657545/214554140-19e2d72f-124f-4d84-bb16-8ddb101e1272.png)


토큰이 잘못된 경우에는 아래와 같이 에러가 발생하므로, 카카오 로그인을 통해 발급된 Access Token을 통해
로그인하는 기능이 정상적으로 동작함을 확인할 수 있다.
![image](https://user-images.githubusercontent.com/62657545/214554195-ee650531-15be-4097-9b3f-8c1df4c3e729.png)
